### PR TITLE
fix: types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 declare module "react-native-image-colors" {
   export function getColors<C extends Config>(
     url: string,
-    config: C
+    config?: C
   ): Promise<AndroidImageColors | IOSImageColors>;
 }
 


### PR DESCRIPTION
since we don't have any required options in config, we can have the config parameter an optional parameter, it will reduce the typescript compiler warning.